### PR TITLE
Establish outline for AP-Hunt

### DIFF
--- a/ap-hunt-v1.0.md
+++ b/ap-hunt-v1.0.md
@@ -82,7 +82,35 @@ For complete copyright information please see the full Notices section in an App
 -------
 
 # Table of Contents
-[[TOC will be inserted here]]
+- [1 Introduction](#1-introduction)
+  - [1.1 Changes from earlier versions](#11-changes-from-earlier-versions)
+  - [1.2 Glossary](#12-glossary)
+    - [1.2.1 Definitions of terms](#121-definitions-of-terms)
+    - [1.2.2 Acronyms and abbreviations](#122-acronyms-and-abbreviations)
+    - [1.2.3 Document conventions](#123-document-conventions)
+  - [1.5 Overview](#15-overview)
+  - [1.6 Goal](#16-goal)
+  - [1.7 Purpose and Scope](#17-purpose-and-scope)
+- [2 2 OpenC2 Language Binding for Threat Hunting](#2-2-openc2-language-binding-for-threat-hunting)
+  - [2.1 OpenC2 Command Components](#21-openc2-command-components)
+    - [2.1.1 Actions](#211-actions)
+    - [2.1.2 Targets](#212-targets)
+    - [2.1.3 Type Definitions](#213-type-definitions)
+    - [2.1.4 Command Arguments](#214-command-arguments)
+    - [2.1.5 Actuator Specifiers](#215-actuator-specifiers)
+  - [2.2 OpenC2 Response Components](#22-openc2-response-components)
+    - [2.2.1 Response Status Codes](#221-response-status-codes)
+  - [2.3 OpenC2 Commands](#23-openc2-commands)
+    - [2.3.1 Query](#231-query)
+    - [2.3.2 Investigate](#232-investigate)
+- [3 Conformance](#3-conformance)
+- [Appendix A. References](#appendix-a-references)
+- [Appendix B. Safety, Security and Privacy Considerations](#appendix-b-safety-security-and-privacy-considerations)
+- [Appendix C. Acknowledgments](#appendix-c-acknowledgments)
+- [Appendix D. Revision History](#appendix-d-revision-history)
+- [Appendix E. Threat Hunting Command / Response Examples](#appendix-e-threat-hunting-command--response-examples)
+- [Appendix F. Notices](#appendix-f-notices)
+
 
 -------
 
@@ -110,158 +138,36 @@ Introductory text.
 - Font colors and styles
 - Typographic conventions
 
-## 1.3 Some markdown usage examples
+## 1.5 Overview
 
-**Text.**
+## 1.6 Goal
 
-Note that text paragraphs in markdown should be separated by a blank line between them -
-
-Otherwise the separate paragraphs will be joined together when the HTML is generated.
-Even if the text appears to be separate lines in the markdown source.
-
-To avoid having the usual vertical space between paragraphs,  
-append two or more space characters (or space-backslash) to the end of the lines  
-which will generate an HTML break tag instead of a new paragraph tag \
-(as demonstrated here).
-
-### 1.3.1 Figures and Captions
-
-FIGURE EXAMPLE:
-<note caption is best placed ABOVE figure, so a hyperlink to it will actually display the figure, instead of rendering the figure off the screen above the caption. The same placement should be used for table captions>
-
-###### Figure 1 -- Title of Figure
-![image-label should be meaningful](images/image_0.png) (this image is intentionally missing)
-
-###### Figure 2 -- OpenC2 Message Exchange
-![message exchange](images/image_1.png)
-
-
-### 1.3.2 Tables
-
-#### 1.3.2.1 Basic Table
-**Table 1-1. Table Label**
-
-| Item | Description |
-| :--- | :--- |
-| Item 1 | Something<br>(second line) |
-| Item 2 | Something |
-| Item 3 | Something<br>(second line) |
-| Item 4 | text |
-
-#### 1.3.2.2 Table with Three Columns and Some Bold Text
-text.
-
-| Title 1 | Title 2 | title 3 |
-| :--- | :--- | :--- |
-| something | something | something else that is a long string of text that **might** need to wrap around inside the table box and will just continue until the column divider is reached |
-| something | something | something |
-
-#### 1.3.2.3 Table with a caption which can be referenced
-
-###### Table 1-5. See reference label construction
-
-| Name | Description |
-| :--- | :--- |
-| **content** | Message body as specified by content_type and msg_type. |
-
-Here is a reference to the table caption:
-Please see [Table 1-5 or other meaningful label](#table-1-5-see-reference-label-construction) 
-
-
-### 1.3.3 Lists
-
-Bulleted list:
-* bullet item 1.
-* **Bold** bullet item 2.
-* bullet item 3.
-* bullet item 4.
-
-Indented or multi-level bullet list - add two spaces per level before bullet character (* or -):
-* main bullet type
-  * Example second bullet
-    * See third level
-      * fourth level
-
-Numbered list:
-1. item 1
-2. item 2
-3. item 3
-
-Left-justified list without bullets or numbers:
-To list multiple items without full paragraph breaks between items, add space-backslash after each item except the last.
-
-### 1.3.4 Reference Label Construction
-
-REFERENCES and ANCHORS
-- in markdown source, format the Reference tags as level 6 headings like: `###### [RFC2119]`
-###### [RFC2119]
-Bradner, S., "Key words ..."
-
-- reference text has to be on a separate line below the tag
-
-- format cross-references (citations of the references) like: `see [[RFC2119](#rfc2119)]`  
-"see [[RFC2119](#rfc2119)]"  
-(note the outer square brackets in markdown will appear in the visible HTML text)
-
-- The text in the Reference tag (following ###### ) will become an HTML anchor using the following conversion rules:  
-  - punctuation marks will be dropped (including "[" )  
-  - leading white spaces will be dropped  
-  - upper case will be converted to lower  
-  - spaces between letters will be converted to a single hyphen
-
-- The same HTML anchor construction rules apply to cross-references and to section headings.  
-  - Thus, a section heading like "## 1.2 Glossary"  
-  - becomes an anchor in HTML like `<a href="#12-glossary">`  
-  - referenced in the markdown like: see [Section 1.2](#12-glossary)  
-  - in markdown: `"see [Section 1.2](#12-glossary)"`  
-  - similar HTML anchors are also used in constructing the TOC
-
-### 1.3.5 Code Blocks
-
-Text to appear as an indented code block with grey background and monospace font - use three back-ticks before and after the code block.
-
-Note the actual backticks will not appear in the HTML format. If it's necessary to display visible backticks, place a back-slash before them like: \``` .
-
-```
-{   
-    "target": {
-        "x_kmip_2.0": {
-            {"kmip_type": "json"},
-            {"operation": "RekeyKeyPair"},
-            {"name": "publicWebKey11DEC2017"}
-        }
-    }
-}
-```
-
-Text to be highlighted as code can also be surrounded by a single "backtick" character: 
-`code text`
-
-## 1.4 Page Breaks
-Add horizontal rule lines where page breaks are desired in the PDF - before each major section
-- insert the line rules in markdown by inserting 3 or more hyphens on a line by themselves:  ---
-- place these before each main section in markdown (usually "#" - which generates the HTML `<h1>` tag)
-
+## 1.7 Purpose and Scope
 -------
 
-# 2 Section Heading
-text.
+# 2 2 OpenC2 Language Binding for Threat Hunting
 
-## 2.1 Level 2 Heading
-text.
+## 2.1 OpenC2 Command Components
 
-### 2.1.1 Level 3 Heading
-text.
+### 2.1.1 Actions
 
-#### 2.1.1.1 Level 4 Heading
-text.
+### 2.1.2 Targets
 
-##### 2.1.1.1.1 Level 5 Heading
-This is the deepest level, because six # gets transformed into a Reference tag.
+### 2.1.3 Type Definitions
 
+### 2.1.4 Command Arguments
 
-## 2.2 Next Heading
-text.
+### 2.1.5 Actuator Specifiers
+
+## 2.2 OpenC2 Response Components
+
+### 2.2.1 Response Status Codes
+
+## 2.3 OpenC2 Commands
+
+### 2.3.1 Query
+
+### 2.3.2 Investigate
 
 -------
 
@@ -371,15 +277,15 @@ Darren | Anstman | Big Networks
 
 | Revision | Date | Editor | Changes Made |
 | :--- | :--- | :--- | :--- |
-| specname-v1.0-wd01 | yyyy-mm-dd | Editor Name | Initial working draft |
+| ap-hunt-v1.0-wd01 | yyyy-mm-dd | Editor Name | Initial working draft |
 
 -------
 
-# Appendix E. Example Appendix with subsections
+# Appendix E. Threat Hunting Command / Response Examples
 
-## E.1 Subsection title
+## E.1 Example 1
 
-### E.1.1 Sub-subsection
+## E.2 Example 2
 
 -------
 


### PR DESCRIPTION
Outline based on in-development ER AP, factored against OASIS starter document outline.

Deletes example markdown in section 1, establishes section 1 & 2 structures, assigns Appendix E for command / response examples.